### PR TITLE
feat: landing page and navbar (#2)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,19 @@
-:root { --bg: #ffffff; --fg: #111111; }
-html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg); font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; }
-a { text-decoration: underline; }
+@import "tailwindcss";
+
+:root {
+  color-scheme: light;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+a {
+  @apply underline-offset-4 transition-colors;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,24 @@
-import './globals.css';
+import type { Metadata } from "next";
 
-export const metadata = {
-  title: 'swarm-sandbox',
-  description: 'demo',
+import "./globals.css";
+
+import { Footer } from "@/components/ui/footer";
+import { Navbar } from "@/components/ui/navbar";
+import { siteConfig } from "@/content/site";
+
+export const metadata: Metadata = {
+  title: siteConfig.name,
+  description: siteConfig.description,
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body>{children}</body>
+    <html lang="en" className="bg-slate-50">
+      <body className="flex min-h-screen flex-col bg-white text-slate-900 antialiased">
+        <Navbar />
+        <main className="flex-1">{children}</main>
+        <Footer />
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,106 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+import { FAQ } from "@/components/ui/faq";
+import { FeatureCard } from "@/components/ui/feature-card";
+import { LogoStrip } from "@/components/ui/logo-strip";
+import { Pricing } from "@/components/ui/pricing";
+import { siteConfig } from "@/content/site";
+
+export const metadata: Metadata = {
+  title: `${siteConfig.name} | ${siteConfig.hero.title}`,
+  description: siteConfig.description,
+};
+
 export default function Page() {
   return (
-    <main className="min-h-screen p-8">
-      <h1 className="text-3xl font-semibold">Hello from swarm-sandbox 👋</h1>
-      <p>Deployed via Vercel.</p>
-      <a className="underline" href="/dashboard">Go to dashboard</a>
+    <main className="bg-white">
+      <section className="relative overflow-hidden bg-gradient-to-b from-slate-50 via-white to-white">
+        <div className="mx-auto max-w-6xl px-4 py-20 sm:px-6 sm:py-24 lg:py-32">
+          <div className="grid gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,420px)] lg:items-center">
+            <div className="space-y-8">
+              <span className="inline-flex items-center rounded-full border border-blue-100 bg-blue-50 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
+                {siteConfig.hero.eyebrow}
+              </span>
+              <h1 className="text-4xl font-semibold tracking-tight text-slate-900 sm:text-5xl">
+                {siteConfig.hero.title}
+              </h1>
+              <p className="max-w-xl text-lg leading-7 text-slate-600">
+                {siteConfig.hero.description}
+              </p>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <Link
+                  href={siteConfig.hero.primaryCta.href}
+                  className="inline-flex items-center justify-center rounded-full bg-blue-600 px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700"
+                >
+                  {siteConfig.hero.primaryCta.label}
+                </Link>
+                <Link
+                  href={siteConfig.hero.secondaryCta.href}
+                  className="inline-flex items-center justify-center rounded-full border border-slate-200 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+                >
+                  {siteConfig.hero.secondaryCta.label}
+                </Link>
+              </div>
+            </div>
+            <div className="relative">
+              <div className="absolute -inset-4 rounded-3xl bg-gradient-to-br from-blue-100 via-transparent to-purple-100 blur-2xl" aria-hidden="true" />
+              <div className="relative overflow-hidden rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-xl backdrop-blur">
+                <div className="space-y-4">
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <p className="text-sm font-semibold text-slate-500">Active initiatives</p>
+                      <p className="text-3xl font-semibold text-slate-900">12</p>
+                    </div>
+                    <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">+18% MoM</span>
+                  </div>
+                  <div className="grid grid-cols-3 gap-3 text-center text-sm">
+                    <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                      <p className="text-xs uppercase text-slate-500">Launches</p>
+                      <p className="mt-1 text-lg font-semibold text-slate-900">5</p>
+                    </div>
+                    <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                      <p className="text-xs uppercase text-slate-500">NPS</p>
+                      <p className="mt-1 text-lg font-semibold text-slate-900">+42</p>
+                    </div>
+                    <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                      <p className="text-xs uppercase text-slate-500">Feedback</p>
+                      <p className="mt-1 text-lg font-semibold text-slate-900">248</p>
+                    </div>
+                  </div>
+                  <div className="rounded-2xl border border-blue-100 bg-blue-50 p-4 text-sm text-blue-700">
+                    “PulsePilot is the connective tissue between product strategy and execution. Our team has never shipped faster.”
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <LogoStrip />
+
+      <section id="features" className="py-20 sm:py-24">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6">
+          <div className="mx-auto max-w-2xl text-center">
+            <h2 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
+              Everything you need to run product ops
+            </h2>
+            <p className="mt-4 text-base text-slate-600">
+              Align roadmaps, stakeholders, and customer insights with an opinionated workspace designed for momentum.
+            </p>
+          </div>
+          <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+            {siteConfig.features.map(feature => (
+              <FeatureCard key={feature.title} {...feature} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <Pricing />
+
+      <FAQ />
     </main>
   );
 }

--- a/components/ui/faq.tsx
+++ b/components/ui/faq.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+
+import type { FAQItem } from "@/content/site";
+import { siteConfig } from "@/content/site";
+
+type FAQProps = {
+  items?: FAQItem[];
+};
+
+export function FAQ({ items = siteConfig.faq }: FAQProps) {
+  const [openIndex, setOpenIndex] = useState<number | null>(0);
+
+  const toggle = (index: number) => {
+    setOpenIndex(current => (current === index ? null : index));
+  };
+
+  return (
+    <section id="faq" className="bg-slate-50 py-20 sm:py-24">
+      <div className="mx-auto max-w-4xl px-4 sm:px-6">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-3xl font-semibold text-slate-900 sm:text-4xl">Frequently asked questions</h2>
+          <p className="mt-4 text-base text-slate-600">
+            Answers to common questions about getting started with PulsePilot.
+          </p>
+        </div>
+        <dl className="mt-12 space-y-4">
+          {items.map((item, index) => {
+            const isOpen = openIndex === index;
+            return (
+              <div key={item.question} className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
+                <dt>
+                  <button
+                    type="button"
+                    className="flex w-full items-center justify-between gap-4 px-6 py-5 text-left text-base font-semibold text-slate-900 transition hover:bg-slate-50"
+                    aria-expanded={isOpen}
+                    onClick={() => toggle(index)}
+                  >
+                    <span>{item.question}</span>
+                    <svg
+                      className={`h-5 w-5 flex-shrink-0 text-slate-500 transition-transform ${isOpen ? "rotate-45" : "rotate-0"}`}
+                      viewBox="0 0 20 20"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                    >
+                      <path strokeLinecap="round" d="M10 4.5v11" />
+                      <path strokeLinecap="round" d="M4.5 10h11" />
+                    </svg>
+                  </button>
+                </dt>
+                <dd className={`px-6 pb-6 text-sm leading-6 text-slate-600 transition ${isOpen ? "block" : "hidden"}`}>
+                  {item.answer}
+                </dd>
+              </div>
+            );
+          })}
+        </dl>
+      </div>
+    </section>
+  );
+}

--- a/components/ui/feature-card.tsx
+++ b/components/ui/feature-card.tsx
@@ -1,0 +1,17 @@
+import type { Feature } from "@/content/site";
+
+export function FeatureCard({ icon, title, description }: Feature) {
+  return (
+    <article className="flex h-full flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-lg">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-50 text-2xl">
+        <span role="img" aria-hidden="true">
+          {icon}
+        </span>
+      </div>
+      <div className="space-y-2">
+        <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
+        <p className="text-sm leading-6 text-slate-600">{description}</p>
+      </div>
+    </article>
+  );
+}

--- a/components/ui/footer.tsx
+++ b/components/ui/footer.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+
+import { siteConfig } from "@/content/site";
+
+export function Footer() {
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="border-t border-slate-200 bg-slate-50/60">
+      <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6">
+        <div className="grid gap-8 md:grid-cols-4">
+          <div className="space-y-3">
+            <span className="text-lg font-semibold text-slate-900">{siteConfig.name}</span>
+            <p className="text-sm text-slate-600">{siteConfig.description}</p>
+          </div>
+          {siteConfig.footer.links.map(group => (
+            <div key={group.title} className="space-y-3">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+                {group.title}
+              </h3>
+              <ul className="space-y-2 text-sm text-slate-600">
+                {group.links.map(link => {
+                  const isInternal = link.href.startsWith("/") || link.href.startsWith("#");
+                  return (
+                    <li key={link.label}>
+                      {isInternal ? (
+                        <Link href={link.href} className="transition hover:text-slate-900">
+                          {link.label}
+                        </Link>
+                      ) : (
+                        <a href={link.href} className="transition hover:text-slate-900">
+                          {link.label}
+                        </a>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          ))}
+        </div>
+        <div className="mt-10 border-t border-slate-200 pt-6 text-sm text-slate-500">
+          © {year} {siteConfig.name}. All rights reserved.
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/components/ui/logo-strip.tsx
+++ b/components/ui/logo-strip.tsx
@@ -1,0 +1,23 @@
+import { siteConfig } from "@/content/site";
+
+export function LogoStrip() {
+  return (
+    <section className="bg-slate-50/70 py-12">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <p className="text-center text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">
+          Trusted by modern teams
+        </p>
+        <div className="mt-8 grid grid-cols-2 items-center gap-4 text-center text-sm font-medium text-slate-500 sm:grid-cols-3 md:grid-cols-6">
+          {siteConfig.logos.map(logo => (
+            <div
+              key={logo}
+              className="rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-sm"
+            >
+              {logo}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/ui/navbar.tsx
+++ b/components/ui/navbar.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+import { siteConfig } from "@/content/site";
+
+export function Navbar() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-slate-200 bg-white/90 backdrop-blur">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
+        <Link href="/" className="text-lg font-semibold text-slate-900">
+          {siteConfig.name}
+        </Link>
+        <nav className="hidden items-center gap-8 text-sm font-medium text-slate-600 md:flex">
+          {siteConfig.nav.map(item => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="transition-colors hover:text-slate-900"
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-md border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 md:hidden"
+          onClick={() => setIsOpen(open => !open)}
+          aria-expanded={isOpen}
+          aria-controls="mobile-menu"
+        >
+          <span className="sr-only">Toggle navigation</span>
+          {isOpen ? (
+            <svg className="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 6l8 8M6 14L14 6" />
+            </svg>
+          ) : (
+            <svg className="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3.5 6h13M3.5 10h13M3.5 14h13" />
+            </svg>
+          )}
+        </button>
+      </div>
+      <div
+        id="mobile-menu"
+        className={`border-t border-slate-200 bg-white md:hidden ${isOpen ? "block" : "hidden"}`}
+      >
+        <nav className="space-y-1 px-4 py-4 text-base font-medium text-slate-700">
+          {siteConfig.nav.map(item => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="block rounded-lg px-3 py-2 transition hover:bg-slate-100"
+              onClick={() => setIsOpen(false)}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/components/ui/pricing.tsx
+++ b/components/ui/pricing.tsx
@@ -1,0 +1,88 @@
+import Link from "next/link";
+
+import type { PricingTier } from "@/content/site";
+import { siteConfig } from "@/content/site";
+
+type PricingProps = {
+  tiers?: PricingTier[];
+};
+
+export function Pricing({ tiers = siteConfig.pricing }: PricingProps) {
+  return (
+    <section id="pricing" className="bg-white py-20 sm:py-24">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
+            Flexible plans for every stage
+          </h2>
+          <p className="mt-4 text-base text-slate-600">
+            Choose a plan that grows with your team. Upgrade, downgrade, or cancel anytime.
+          </p>
+        </div>
+        <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {tiers.map(tier => (
+            <article
+              key={tier.name}
+              className={`flex flex-col rounded-3xl border bg-white p-8 shadow-sm transition hover:-translate-y-1 hover:shadow-lg ${
+                tier.highlighted
+                  ? "border-blue-500 ring-2 ring-blue-100"
+                  : "border-slate-200"
+              }`}
+            >
+              {tier.highlighted && (
+                <span className="mb-4 inline-flex w-fit items-center rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
+                  Most popular
+                </span>
+              )}
+              <h3 className="text-xl font-semibold text-slate-900">{tier.name}</h3>
+              <p className="mt-2 text-sm text-slate-600">{tier.description}</p>
+              <div className="mt-6 flex items-baseline gap-1 text-3xl font-semibold text-slate-900">
+                <span>{tier.price}</span>
+                {tier.frequency && <span className="text-base font-normal text-slate-500">{tier.frequency}</span>}
+              </div>
+              <ul className="mt-6 flex-1 space-y-3 text-sm text-slate-600">
+                {tier.features.map(feature => (
+                  <li key={feature} className="flex items-start gap-2">
+                    <svg className="mt-1 h-4 w-4 flex-shrink-0 text-blue-600" viewBox="0 0 16 16" fill="none">
+                      <path
+                        d="M12.6666 4.66669L6.24992 11.3334L3.33325 8.33335"
+                        stroke="currentColor"
+                        strokeWidth="1.6"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                    <span>{feature}</span>
+                  </li>
+                ))}
+              </ul>
+              {tier.cta.href.startsWith("/") ? (
+                <Link
+                  href={tier.cta.href}
+                  className={`mt-8 inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition ${
+                    tier.highlighted
+                      ? "bg-blue-600 text-white hover:bg-blue-700"
+                      : "border border-slate-200 text-slate-700 hover:border-slate-300 hover:bg-slate-50"
+                  }`}
+                >
+                  {tier.cta.label}
+                </Link>
+              ) : (
+                <a
+                  href={tier.cta.href}
+                  className={`mt-8 inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition ${
+                    tier.highlighted
+                      ? "bg-blue-600 text-white hover:bg-blue-700"
+                      : "border border-slate-200 text-slate-700 hover:border-slate-300 hover:bg-slate-50"
+                  }`}
+                >
+                  {tier.cta.label}
+                </a>
+              )}
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/content/site.ts
+++ b/content/site.ts
@@ -1,0 +1,171 @@
+export type NavItem = {
+  label: string;
+  href: string;
+};
+
+export type Feature = {
+  icon: string;
+  title: string;
+  description: string;
+};
+
+export type PricingTier = {
+  name: string;
+  price: string;
+  frequency: string;
+  description: string;
+  cta: {
+    label: string;
+    href: string;
+  };
+  highlighted?: boolean;
+  features: string[];
+};
+
+export type FAQItem = {
+  question: string;
+  answer: string;
+};
+
+export type FooterLinkGroup = {
+  title: string;
+  links: NavItem[];
+};
+
+export const siteConfig = {
+  name: "PulsePilot",
+  description:
+    "PulsePilot centralizes customer feedback and release plans so your product org can move with focus and clarity.",
+  nav: [
+    { label: "Home", href: "/" },
+    { label: "Dashboard", href: "/dashboard" },
+  ] satisfies NavItem[],
+  hero: {
+    eyebrow: "Product Ops for high-velocity teams",
+    title: "Bring every roadmap into focus",
+    description:
+      "PulsePilot connects strategy, execution, and customer insights in one place. Give every teammate the context they need to ship faster and delight customers.",
+    primaryCta: { label: "Start for free", href: "/dashboard" },
+    secondaryCta: { label: "View pricing", href: "#pricing" },
+  },
+  logos: ["Arc", "Vercel", "Linear", "Pitch", "Raycast", "Novel"],
+  features: [
+    {
+      icon: "🧭",
+      title: "Guided roadmaps",
+      description:
+        "Plan, prioritize, and communicate product roadmaps with clarity so every launch stays on track.",
+    },
+    {
+      icon: "📊",
+      title: "Insight dashboards",
+      description:
+        "Translate feedback into actionable themes and share dashboards that keep leadership aligned.",
+    },
+    {
+      icon: "⚡",
+      title: "Automated workflows",
+      description:
+        "Eliminate manual updates with rules that route updates to the right owners instantly.",
+    },
+    {
+      icon: "🤝",
+      title: "Customer-ready briefs",
+      description:
+        "Turn roadmap milestones into polished narratives tailored to customer-facing teams.",
+    },
+  ] satisfies Feature[],
+  pricing: [
+    {
+      name: "Starter",
+      price: "$0",
+      frequency: "/month",
+      description: "For individuals experimenting with product ops.",
+      cta: { label: "Get started", href: "/dashboard" },
+      features: [
+        "Unlimited personal boards",
+        "1 shared workspace",
+        "Feedback inbox",
+      ],
+    },
+    {
+      name: "Growth",
+      price: "$29",
+      frequency: "/seat",
+      description: "Best for growing product teams that need cross-functional visibility.",
+      cta: { label: "Start free trial", href: "/dashboard" },
+      highlighted: true,
+      features: [
+        "Unlimited workspaces",
+        "AI-powered summaries",
+        "Advanced permissions",
+        "Custom integrations",
+      ],
+    },
+    {
+      name: "Scale",
+      price: "Let's chat",
+      frequency: "",
+      description: "Enterprise-grade security and tailored onboarding.",
+      cta: { label: "Talk to sales", href: "mailto:sales@pulsepilot.io" },
+      features: [
+        "Dedicated success manager",
+        "SOC 2 Type II compliance",
+        "Custom data residency",
+        "White-glove migration",
+      ],
+    },
+  ] satisfies PricingTier[],
+  faq: [
+    {
+      question: "How does the free plan work?",
+      answer:
+        "Create a workspace, invite collaborators, and explore every core feature. Upgrade only when you're ready to scale across teams.",
+    },
+    {
+      question: "Can I import data from my existing tools?",
+      answer:
+        "Yes. PulsePilot integrates with the tools you already use—import from spreadsheets, project trackers, and feedback forms in minutes.",
+    },
+    {
+      question: "Is there a discount for startups?",
+      answer:
+        "Absolutely. Early-stage startups under 25 employees qualify for 50% off the Growth plan for the first year.",
+    },
+    {
+      question: "Do you support single sign-on (SSO)?",
+      answer:
+        "SSO is available on the Scale plan with support for SAML and SCIM provisioning.",
+    },
+  ] satisfies FAQItem[],
+  footer: {
+    links: [
+      {
+        title: "Product",
+        links: [
+          { label: "Features", href: "#features" },
+          { label: "Pricing", href: "#pricing" },
+          { label: "FAQ", href: "#faq" },
+        ],
+      },
+      {
+        title: "Company",
+        links: [
+          { label: "About", href: "#" },
+          { label: "Careers", href: "#" },
+          { label: "Blog", href: "#" },
+        ],
+      },
+      {
+        title: "Connect",
+        links: [
+          { label: "Contact", href: "mailto:hello@pulsepilot.io" },
+          { label: "LinkedIn", href: "#" },
+          { label: "Support", href: "#" },
+        ],
+      },
+    ] satisfies FooterLinkGroup[],
+  },
+} as const;
+
+export type SiteConfig = typeof siteConfig;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "19.1.0",
@@ -22,6 +23,13 @@
     "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.5.4",
-    "@eslint/eslintrc": "^3"
+    "@eslint/eslintrc": "^3",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/testing-library__jest-dom": "^6.0.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^26.0.0",
+    "vitest": "^2.1.8"
   }
 }

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,0 +1,11 @@
+import "@testing-library/jest-dom/vitest";
+import type { ComponentProps } from "react";
+import React from "react";
+import { vi } from "vitest";
+
+// Provide a minimal Next.js Link mock for component tests.
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children, ...props }: ComponentProps<"a"> & { href: string }) =>
+    React.createElement("a", { href, ...props }, children),
+}));

--- a/tests/faq.test.tsx
+++ b/tests/faq.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { FAQ } from "@/components/ui/faq";
+
+const mockItems = [
+  { question: "What is PulsePilot?", answer: "PulsePilot is a product ops platform." },
+];
+
+describe("FAQ", () => {
+  it("toggles answers open and closed", async () => {
+    const user = userEvent.setup();
+    render(<FAQ items={mockItems} />);
+
+    const questionButton = screen.getByRole("button", { name: /what is pulsepilot/i });
+    const answer = screen.getByText(/product ops platform/i);
+
+    expect(answer).toBeVisible();
+
+    await user.click(questionButton);
+    expect(answer).not.toBeVisible();
+
+    await user.click(questionButton);
+    expect(answer).toBeVisible();
+  });
+});

--- a/tests/navbar.test.tsx
+++ b/tests/navbar.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+
+import { Navbar } from "@/components/ui/navbar";
+
+describe("Navbar", () => {
+  it("renders dashboard link", () => {
+    render(<Navbar />);
+
+    const dashboardLink = screen.getByRole("link", { name: /dashboard/i });
+    expect(dashboardLink).toBeInTheDocument();
+    expect(dashboardLink).toHaveAttribute("href", "/dashboard");
+  });
+});

--- a/types/vite-plugins.d.ts
+++ b/types/vite-plugins.d.ts
@@ -1,0 +1,8 @@
+declare module "@vitejs/plugin-react" {
+  const plugin: (...args: unknown[]) => unknown;
+  export default plugin;
+}
+
+declare module "vitest/config" {
+  export function defineConfig(config: unknown): unknown;
+}

--- a/types/vitest.d.ts
+++ b/types/vitest.d.ts
@@ -1,0 +1,6 @@
+declare module "vitest" {
+  type MockImplementation = (...args: unknown[]) => unknown;
+  export const vi: {
+    mock: (moduleName: string, factory: MockImplementation) => void;
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: ["./setupTests.ts"],
+    include: ["tests/**/*.test.{ts,tsx}"],
+    css: true,
+  },
+});


### PR DESCRIPTION
## Summary
- build a marketing-focused home page with hero, logo strip, features, pricing, and FAQ content driven by `siteConfig`
- add shared UI components (navbar, footer, pricing, FAQ, logo strip, feature card) and register them in the app layout
- configure vitest with React Testing Library setup and add coverage for navbar navigation and FAQ accordion toggling

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test -- --run` *(fails locally: vitest CLI unavailable in sandbox due to blocked registry)*

Closes #2

Vercel preview: https://swarm-sandbox-git-feat-landing-page-2.vercel.app

![Landing page](browser:/invocations/mdfpepyn/artifacts/artifacts/landing-page.png)


------
https://chatgpt.com/codex/tasks/task_e_68e2c82e9f4883308e87bf08890cb01e